### PR TITLE
Support trailing slashes in GNU-format long file names

### DIFF
--- a/fixtures/gnu_long_filename.a
+++ b/fixtures/gnu_long_filename.a
@@ -1,0 +1,6 @@
+!<arch>
+//              -621355968000     0     100420  24        `
+test_long_filename.txt/
+/0              1542225207  502   0     100644  33        `
+test a file with a long filename
+

--- a/reader.go
+++ b/reader.go
@@ -137,6 +137,9 @@ func (rd *Reader) readHeader() (*Header, error) {
 			if idx := bytes.IndexByte(data, '\n'); idx != -1 {
 				data = data[:idx]
 			}
+			if idx := bytes.IndexByte(data, '/'); idx != -1 {
+				data = data[:idx]
+			}
 			header.Name = string(data)
 		}
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -114,19 +114,29 @@ func TestReadMulti(t *testing.T) {
 	}
 }
 
-func TestBSDFilename(t *testing.T) {
-	f, err := os.Open("./fixtures/bsd_long_filename.a")
-	assert.NoError(t, err)
-	defer f.Close()
-	reader := NewReader(f)
-	var buf bytes.Buffer
-	hdr, err := reader.Next()
-	assert.NoError(t, err)
-	assert.Equal(t, "test_long_filename.txt", hdr.Name)
-	assert.EqualValues(t, 33, hdr.Size)
-	io.Copy(&buf, reader)
-	expected := []byte("test a file with a long filename\n")
-	assert.EqualValues(t, hdr.Size, len(expected))
-	actual := buf.Bytes()
-	assert.Equal(t, expected, actual)
+func TestLongFilename(t *testing.T) {
+	for _, tc := range []struct {
+		Description string
+		ArchivePath string
+	}{
+		{"BSD format", "./fixtures/bsd_long_filename.a"},
+		{"GNU format", "./fixtures/gnu_long_filename.a"},
+	} {
+		t.Run(tc.Description, func(t *testing.T) {
+			f, err := os.Open(tc.ArchivePath)
+			assert.NoError(t, err)
+			defer f.Close()
+			reader := NewReader(f)
+			var buf bytes.Buffer
+			hdr, err := reader.Next()
+			assert.NoError(t, err)
+			assert.Equal(t, "test_long_filename.txt", hdr.Name)
+			assert.EqualValues(t, 33, hdr.Size)
+			io.Copy(&buf, reader)
+			expected := []byte("test a file with a long filename\n")
+			assert.EqualValues(t, hdr.Size, len(expected))
+			actual := buf.Bytes()
+			assert.Equal(t, expected, actual)
+		})
+	}
 }

--- a/writer.go
+++ b/writer.go
@@ -121,6 +121,7 @@ func (aw *Writer) WriteGlobalHeaderForLongFiles(filenames []string) error {
 		if len(filename) >= 16 {
 			aw.longFilenames[filename] = len(data)
 			data = append(data, []byte(filename)...)
+			data = append(data, '/')
 			data = append(data, '\n')
 		}
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -127,6 +127,33 @@ func TestIoCopyWithoutPadding(t *testing.T) {
 	}
 }
 
+func TestWriteGNUFilename(t *testing.T) {
+	hdr := &Header{}
+	body := "test a file with a long filename\n"
+	hdr.ModTime = time.Unix(1542225207, 0)
+	hdr.Name = "test_long_filename.txt"
+	hdr.Size = int64(len(body))
+	hdr.Mode = 0644
+	hdr.Uid = 502
+	hdr.Gid = 0
+
+	var buf bytes.Buffer
+	writer := NewWriter(&buf)
+	writer.WriteGlobalHeaderForLongFiles([]string{"test_long_filename.txt"})
+	writer.WriteHeader(hdr)
+	_, err := writer.Write([]byte(body))
+	assert.NoError(t, err)
+
+	f, _ := os.Open("./fixtures/gnu_long_filename.a")
+	defer f.Close()
+
+	b, err := ioutil.ReadAll(f)
+	assert.NoError(t, err)
+
+	actual := buf.Bytes()
+	assert.Equal(t, b, actual)
+}
+
 func TestWriteBSDFilename(t *testing.T) {
 	hdr := &Header{}
 	body := "test a file with a long filename\n"


### PR DESCRIPTION
GNU ar uses a trailing slash to denote the end of a long file name (see byte offset 5a in the following):

```
$ echo "test a file with a long filename" > test_long_filename.txt
$ ar r test.ar test_long_filename.txt
$ xxd test.ar
00000000: 213c 6172 6368 3e0a 2f2f 2020 2020 2020  !<arch>.//
00000010: 2020 2020 2020 2020 2020 2020 2020 2020
00000020: 2020 2020 2020 2020 2020 2020 2020 2020
00000030: 2020 2020 2020 2020 3234 2020 2020 2020          24
00000040: 2020 600a 7465 7374 5f6c 6f6e 675f 6669    `.test_long_fi
00000050: 6c65 6e61 6d65 2e74 7874 2f0a 2f30 2020  lename.txt/./0
00000060: 2020 2020 2020 2020 2020 2020 3020 2020              0
00000070: 2020 2020 2020 2020 3020 2020 2020 3020          0     0
00000080: 2020 2020 3634 3420 2020 2020 3333 2020      644     33
00000090: 2020 2020 2020 600a 7465 7374 2061 2066        `.test a f
000000a0: 696c 6520 7769 7468 2061 206c 6f6e 6720  ile with a long
000000b0: 6669 6c65 6e61 6d65 0a0a                 filename..
```

`Writer` omits this trailing slash when `WriteGlobalHeaderForLongFiles` is used. GNU ar seems to be forgiving about it being missing, but llvm-ar isn't - attempting to read such an archive created by `Writer` with llvm-ar results in the following error:

```
llvm-ar: truncated or malformed archive (string table at long name offset 0not terminated).
```

When writing archives with GNU-format long file names, append a trailing slash to the file name, and when reading archives with GNU-format long file names, strip the trailing slash if it exists (although silently continue if it doesn't). This should ensure that `Reader` can continue reading archives created by previous versions of `Writer` while outputting archives that can be read by llvm-ar:

```
$ ar tv fixtures/gnu_long_filename.a
rw-r--r-- 502/0     33 Nov 14 19:53 2018 test_long_filename.txt
$ ar p fixtures/gnu_long_filename.a test_long_filename.txt
test a file with a long filename
$ llvm-ar tv fixtures/gnu_long_filename.a
rw-r--r-- 502/0     33 2018-11-14 19:53:27.000000000
test_long_filename.txt
$ llvm-ar p fixtures/gnu_long_filename.a test_long_filename.txt
test a file with a long filename
```