### PR TITLE
Fix long filename writing

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -144,7 +144,7 @@ func (aw *Writer) WriteHeader(hdr *Header) error {
 	s := slicer(header)
 
 	var bsdName []byte
-	if len(hdr.Name) >= 16 {
+	if len(hdr.Name) > 16 {
 		idx, present := aw.longFilenames[hdr.Name]
 		if present {
 			// already known, write GNU-style name

--- a/writer.go
+++ b/writer.go
@@ -118,7 +118,7 @@ func (aw *Writer) WriteGlobalHeaderForLongFiles(filenames []string) error {
 	}
 	var data []byte
 	for _, filename := range filenames {
-		if len(filename) >= 16 {
+		if len(filename) > 16 {
 			aw.longFilenames[filename] = len(data)
 			data = append(data, []byte(filename)...)
 			data = append(data, '/')


### PR DESCRIPTION
I'm getting some subtle breakage from #2 (it's a very fiddly test case some way downstream but I've got it bisected there).

`ar t <file>` seems to show unexpected trailing slashes on filenames that are _exactly_ 16 chars long. This changes the comparison; I assume that was always kind of wrong and when they're exactly on the limit they are idiomatically treated as 'short' (and this was working before, but the addition of the extra trailing slash confuses it).

After this, I can create an archive, run `ar -s` on it, and then `objdump -t` doesn't complain about it being malformed any more.